### PR TITLE
Allow user to optionally skip re-running NormalizeData

### DIFF
--- a/R/LDAelbowPlot.R
+++ b/R/LDAelbowPlot.R
@@ -7,6 +7,7 @@
 #' @param Object Object containing the data the model was created with.
 #' @param VarFeatures the number of variable features to use in the LDA model. MUST MATCH WITH MODELS IN model_dir
 #' @param assayName The name of the assay holding the source data
+#' @param skipNormalization If true, the data are assumed to be pre-normalized. Both normalization and Seurat::FindVarialeFeatures() are skipped. Therefore the arguments normalizationMethod and varFeatures are ignored.
 #'
 #' @examples
 #' LDAelbowPlot(test_dir, SeuratObj)
@@ -21,14 +22,16 @@
 #' @import lda
 #'
 LDAelbowPlot <- function(model_dir,
-                         Object, varFeatures = 5000, assayName = "RNA") {
+                         Object, varFeatures = 5000, assayName = "RNA", skipNormalization = FALSE) {
   files <- list.files(path = model_dir, pattern = "Model_")
 
   # Get model input data
   if (class(Object) == "Seurat") {
     #Normalize and extract the gene expression data from the Seurat Object
-    Object        <- NormalizeData(Object, assay = assayName, normalization.method = "CLR")
-    Object        <- FindVariableFeatures(Object, assay = assayName, nfeatures = varFeatures)
+    if (!skipNormalization) {
+      Object        <- NormalizeData(Object, assay = assayName, normalization.method = "CLR")
+      Object        <- FindVariableFeatures(Object, assay = assayName, nfeatures = varFeatures)
+    }
     Object.sparse <- GetAssayData(Object, slot = "data",assay = assayName)
     Object.sparse <- Object.sparse[VariableFeatures(Object, assay = assayName),]
 

--- a/man/LDAelbowPlot.Rd
+++ b/man/LDAelbowPlot.Rd
@@ -4,7 +4,13 @@
 \alias{LDAelbowPlot}
 \title{Topic Elbow Plot}
 \usage{
-LDAelbowPlot(model_dir, Object, varFeatures = 5000, assayName = "RNA")
+LDAelbowPlot(
+  model_dir,
+  Object,
+  varFeatures = 5000,
+  assayName = "RNA",
+  skipNormalization = FALSE
+)
 }
 \arguments{
 \item{model_dir}{Directory containing the models created using a varying number of topics.}
@@ -12,6 +18,8 @@ LDAelbowPlot(model_dir, Object, varFeatures = 5000, assayName = "RNA")
 \item{Object}{Object containing the data the model was created with.}
 
 \item{assayName}{The name of the assay holding the source data}
+
+\item{skipNormalization}{If true, the data are assumed to be pre-normalized. Both normalization and Seurat::FindVarialeFeatures() are skipped. Therefore the arguments normalizationMethod and varFeatures are ignored.}
 
 \item{VarFeatures}{the number of variable features to use in the LDA model. MUST MATCH WITH MODELS IN model_dir}
 }

--- a/man/runLDA.Rd
+++ b/man/runLDA.Rd
@@ -17,7 +17,8 @@ runLDA(
   outDir = NULL,
   cores = 1,
   normalizationMethod = "CLR",
-  assayName = "RNA"
+  assayName = "RNA",
+  skipNormalization = FALSE
 )
 }
 \arguments{
@@ -46,6 +47,8 @@ runLDA(
 \item{normalizationMethod}{Normalization method used by Seurat NormalizeData. Options are CLR, LogNormalize and RC.}
 
 \item{assayName}{The name of the assay holding the source data}
+
+\item{skipNormalization}{If true, the data are assumed to be pre-normalized. Both normalization and Seurat::FindVarialeFeatures() are skipped. Therefore the arguments normalizationMethod and varFeatures are ignored.}
 }
 \value{
 LDA Model


### PR DESCRIPTION
@adoe21: This PR has two features:

- NormalizeData and FindVariableGenes are non-trivial to run on a big dataset, and this allows the user to optionally skip them (such as when data are pre-normalized).
- There's a bug in runLDA when the user enters multiple values for ntopics, but uses parallel=FALSE. This fixes that. 